### PR TITLE
Format code blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ There are some enviroment variables that are required when the docker compose ca
 
 If these are missing when you run docker compose is made, you *will* get a crash at some point of normal operation. Not maybe, will.
 
-- WEBSITE_URL: The URL of the website people are visiting. Needed for stuff like OAuth2 redirect URLs. Do not include trailing slash.
+- `WEBSITE_URL`: The URL of the website people are visiting. Needed for stuff like OAuth2 redirect URLs. Do not include trailing slash.
 
-- POSTGRES_USER, POSTGRES_PASSWORD: The user and password used when creating the postgres DB. Given to both the rust app and the postgres container.
+- `POSTGRES_USER`, `POSTGRES_PASSWORD`: The user and password used when creating the postgres DB. Given to both the rust app and the postgres container.
 
-- AWS_ENDPOINT_URL, AWS_ACCESS_KEY, AWS_SECRET_ACCESS_KEY, AWS_REGION: Information regarding the location and login data for AWS services, so we can use S3 buckets to store images and video and somesuch. *During development, point this at a LocalStack instance.*
+- `AWS_ENDPOINT_URL`, `AWS_ACCESS_KEY`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`: Information regarding the location and login data for AWS services, so we can use S3 buckets to store images and video and somesuch. *During development, point this at a LocalStack instance.*
 
-- DISCORD_OAUTH2_CLIENT_ID, DISCORD_OAUTH2_CLIENT_SECRET: Discord client authentication data for OAuth2. You can get those in the [Discord Developer Portal](https://discord.com/developers/applications). We're using OAuth2 because I do not want to deal with passwords.
+- `DISCORD_OAUTH2_CLIENT_ID`, `DISCORD_OAUTH2_CLIENT_SECRET`: Discord client authentication data for OAuth2. You can get those in the [Discord Developer Portal](https://discord.com/developers/applications). We're using OAuth2 because I do not want to deal with passwords.
 
-- GOOGLE_OAUTH2_CLIENT_ID, GOOGLE_OAUTH2_CLIENT_SECRET: Ditto, for google instead. Get them in the [Google Auth Platform Dashboard](https://console.cloud.google.com/auth/clients).
+- `GOOGLE_OAUTH2_CLIENT_ID`, `GOOGLE_OAUTH2_CLIENT_SECRET`: Ditto, for google instead. Get them in the [Google Auth Platform Dashboard](https://console.cloud.google.com/auth/clients).
 
-- GITHUB_OAUTH2_CLIENT_ID, GITHUB_OAUTH2_CLIENT_SECRET: You get the idea. [Get them here](https://github.com/settings/developers).
+- `GITHUB_OAUTH2_CLIENT_ID`, `GITHUB_OAUTH2_CLIENT_SECRET`: You get the idea. [Get them here](https://github.com/settings/developers).
 
 ### Optional Variables
 
@@ -37,9 +37,9 @@ Each variable will have its default value listed in parantheses.
 
 The various bucket names in S3 for storing the PD-related data. Because every bucket name is unique, you will probably need to change some of these.
 
-- S3_PUBLIC_BUCKET_NAME (powerdown-public-storage): The bucket where we store everything the average user may run into during regular browsing - art, character thumbnails, videos, user pfps, that sort of deal. As the name indicates, should be public access.
+- `S3_PUBLIC_BUCKET_NAME` (`powerdown-public-storage`): The bucket where we store everything the average user may run into during regular browsing - art, character thumbnails, videos, user pfps, that sort of deal. As the name indicates, should be public access.
 
-- S3_SQL_BACKUP_BUCKET_NAME (powerdown-sql-backups-storage): The bucket with backups of the various SQL tables we have going, and it'll read from there to see if there's an existing backup to read from on startup. **Shouldn't be public access**, unless you fancy random people being able to access your OAuth2 access keys.
+- `S3_SQL_BACKUP_BUCKET_NAME` (`powerdown-sql-backups-storage`): The bucket with backups of the various SQL tables we have going, and it'll read from there to see if there's an existing backup to read from on startup. **Shouldn't be public access**, unless you fancy random people being able to access your OAuth2 access keys.
 
 ## Cookies
 
@@ -47,4 +47,4 @@ There are some cookies that we use across the site. Here's the full list of them
 
 You should assume, whenever possible, that these keys aren't assigned. They're cookies, it's very hard to enforce their existence.
 
-- USER_SESSION_ID: The session ID of the user currently logged in; self-explanatory. This cookie should be set to expire before the server's expiration date for the same session hits, purely for convenience.
+- `USER_SESSION_ID`: The session ID of the user currently logged in; self-explanatory. This cookie should be set to expire before the server's expiration date for the same session hits, purely for convenience.


### PR DESCRIPTION
Makes it easier to read environment variable names and the like. Also makes clear that the underscores aren't for italics or anything.